### PR TITLE
Update output files for `apex cis` and `apex store`

### DIFF
--- a/doc/mode_cis/README.md
+++ b/doc/mode_cis/README.md
@@ -18,7 +18,7 @@ cis-xQTL analysis in APEX uses either a) ordinary least squares (OLS) or b) a li
 **Example command:** <br />
  `./apex cis --vcf {vcf} --bed {trait-file} --cov {covariate-file} --prefix {out-name} --long` <br />
 
- **Output files.** The above command generates 3 output files, `{out-name}.cis_sumstats.tsv.gz`, `{out-name}.cis_gene_table.tsv.gz`, `{out-name}.cis_long_table.tsv.gz`.  The `cis_sumstats` output file contains association score statistics in a condensed format, which can be used for downstream analysis with the command `./apex meta`.  Human-readable output files are described below: <br />
+ **Output files.** The above command generates 5 output files, `{out-name}.cis_sumstats.txt.gz`, `{out-name}.cis_sumstats.txt.gz.csi`, `{out-name}.cis_gene_table.txt.gz`, `{out-name}.cis_gene_table.txt.gz.csi`, `{out-name}.cis_long_table.txt.gz`.  The `cis_sumstats` output file contains association score statistics in a condensed format, which can be used for downstream analysis with the command `./apex meta`.  Human-readable output files are described below: <br />
  
 `*.cis_long_table.tsv.gz` (flag `--long`) columns: 
  1. `#chrom` : Variant chromosome.

--- a/doc/mode_store/README.md
+++ b/doc/mode_store/README.md
@@ -21,7 +21,7 @@ Note that APEX vcov files capture covariated-adjusted LD (the covariance of geno
 **Example command:** <br />
  `./apex store --vcf {vcf} --bed {trait-file} --cov {covariate-file} --prefix {out-name}` <br />
 
- **Output files.** The above command generates 3 output files, `{out-name}.vcov.bin`, `{out-name}.vcov.idx.gz`, `{out-name}.cis_long_table.tsv.gz`.  These files store LD data, LD index and covariate adjustment terms, and tabix index respectively. In general, these files are not intended to be human-readable, but can be queried and used for multiple-variant analysis using `apex meta` and `apexR`. <br />
+ **Output files.** The above command generates 3 output files, `{out-name}.vcov.bin`, `{out-name}.vcov.idx.gz`, `{out-name}.vcov.idx.gz.csi`.  These files store LD data, LD index and covariate adjustment terms, and tabix index respectively. In general, these files are not intended to be human-readable, but can be queried and used for multiple-variant analysis using `apex meta` and `apexR`. <br />
 
 ## Command line arguments
 A partial list of options is given below.  Please run `./apex store --help` to see a complete list of command line flags and options. 


### PR DESCRIPTION
For both `apex cis` and `apex store`, the output files returned were different than those described in the documentation pages, but they matched those in the source code, e.g.

https://github.com/corbinq/apex/blob/63b605e00766141693a69eee6d630ad8ec3b9de0/src/cisMapping.cpp#L75-L77